### PR TITLE
fix: typo and add mailto to email links

### DIFF
--- a/ui/rendering-info-cyverse.tsx
+++ b/ui/rendering-info-cyverse.tsx
@@ -19,7 +19,7 @@ export function RenderingInfoCyVerse({
   return (
     <>
       <div className="inline-flex gap-x-2 rounded-lg bg-gray-900 p-2 px-4 py-2">
-        <a href="cyverse-support@tugraz.at">
+        <a href="mailto:cyverse-support@tugraz.at">
           <div className="flex justify-center text-sm font-thin text-white">
             cyverse-support@tugraz.at
           </div>

--- a/ui/rendering-info-elab.tsx
+++ b/ui/rendering-info-elab.tsx
@@ -18,7 +18,7 @@ export function RenderingInfoELab({
 
   return (
     <div className="inline-flex gap-x-2 rounded-lg bg-gray-900 p-2 px-4 py-2">
-      <a href="elabftw-support@tugraz.at">
+      <a href="mailto:elabftw-support@tugraz.at">
         <div className="flex justify-center text-sm font-thin text-white">
           elabftw-support@tugraz.at
         </div>

--- a/ui/rendering-info-repository.tsx
+++ b/ui/rendering-info-repository.tsx
@@ -18,9 +18,9 @@ export function RenderingInfoRepository({
 
   return (
     <div className="inline-flex gap-x-2 rounded-lg bg-gray-900 p-2 px-4 py-2">
-      <a href="repositroy-support@tugraz.at">
+      <a href="mailto:repository-support@tugraz.at">
         <div className="flex justify-center text-sm font-thin text-white">
-          repositroy-support@tugraz.at
+          repository-support@tugraz.at
         </div>
       </a>
     </div>


### PR DESCRIPTION
Fix typo in email.
Add "mailto" to email links.